### PR TITLE
Added tests for mixed attributes by tag type

### DIFF
--- a/tests/HtmlElementTest.php
+++ b/tests/HtmlElementTest.php
@@ -85,4 +85,35 @@ class HtmlElementTest extends TestCase
 
         $this->assertSame('<input required>', $element->render());
     }
+
+    /** @test */
+    function it_generates_a_void_element_with_mixed_attributes()
+    {
+        $element = new HtmlElement(
+            'input',
+            ['id' => 'my_paragraph', 'class' => 'paragraph', 'required'],
+            ''
+        );
+
+        $this->assertSame(
+            '<input id="my_paragraph" class="paragraph" required>',
+            $element->render()
+        );
+    }
+
+    /** @test */
+    function it_generates_an_element_with_mixed_attributes()
+    {
+        $element = new HtmlElement(
+            'textarea',
+            ['id' => 'disabled_paragraph', 'class' => 'paragraph', 'disabled'],
+            'Contenido'
+        );
+
+        $this->assertSame(
+            '<textarea id="disabled_paragraph" class="paragraph" disabled>Contenido</textarea>',
+            $element->render()
+        );
+    }
+
 }


### PR DESCRIPTION
Added two new tests for assert it generates a void tag element with mixed attributes and also generates a normal tag element with mixed attributes